### PR TITLE
manifest: Change to .desktop format

### DIFF
--- a/com.genivi.gdp.connectedhome.desktop
+++ b/com.genivi.gdp.connectedhome.desktop
@@ -1,4 +1,6 @@
+[Desktop Entry]
 Name=Connected Home
+Type=Application
 Icon=file://opt/com.genivi.gdp.connectedhome/share/icons/com.genivi.gdp.connectedhome.svg
 Unit=com.genivi.gdp.connectedhome
-Exec=/opt/com.genivi.gdp.connectedhome/bin/qt-smart-demo
+Exec=/opt/com.genivi.gdp.connectedhome/bin/qt-smart-demo -platform wayland

--- a/com.genivi.gdp.connectedhome.service
+++ b/com.genivi.gdp.connectedhome.service
@@ -1,6 +1,0 @@
-[Unit]
-Description=Connected Home HMI
-
-[Service]
-Environment=LD_PRELOAD=/usr/lib/libEGL.so
-ExecStart=/opt/com.genivi.gdp.connectedhome/bin/qt-smart-demo -platform wayland


### PR DESCRIPTION
Remove .service file as it is no longer used by the GDP HMI
Reformat .app file to a .desktop file

[GDP-555] Mechanism to register & launch apps in HMI

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>